### PR TITLE
Fix tests environment

### DIFF
--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -15,7 +15,7 @@ load_dotenv()
 DATABASE_URL: str = os.getenv("DATABASE_URL_PROD")
 
 if not DATABASE_URL:
-    raise ValueError("DATABASE_URL environment variable is not set")
+    raise ValueError("DATABASE_URL_PROD environment variable is not set")
 
 engine: AsyncEngine = create_async_engine(DATABASE_URL, echo=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 import asyncio
-import pytest_asyncio
+import pytest
 from httpx import AsyncClient, ASGITransport
 from contextlib import asynccontextmanager
 
@@ -34,13 +34,13 @@ async def init_db():
         await conn.run_sync(Base.metadata.create_all)
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 async def initialize_database():
     await init_db()
     yield
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 def event_loop():
     policy = asyncio.get_event_loop_policy()
     loop = policy.new_event_loop()
@@ -48,7 +48,7 @@ def event_loop():
     loop.close()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def test_session():
     session_maker.configure(bind=engine)
     async with session_maker() as session:
@@ -58,7 +58,7 @@ async def test_session():
             await session.close()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def client(test_session):
     app.dependency_overrides[get_session] = lambda: test_session
     async with AsyncClient(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,12 @@ from dotenv import load_dotenv
 import asyncio
 import pytest
 from httpx import AsyncClient, ASGITransport
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncEngine
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncEngine, async_sessionmaker, AsyncSession
 from sqlalchemy.pool import NullPool
 
 from main import app
 from database.base import Base
-from database.connection import get_session, session_maker
+from database.connection import get_session
 
 load_dotenv()
 
@@ -43,7 +43,7 @@ def event_loop():
 
 @pytest.fixture(scope="function")
 async def test_session(engine):
-    session_maker.configure(bind=engine)
+    session_maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     async with session_maker() as session:
         try:
             yield session

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -2,7 +2,6 @@ import pytest
 import httpx
 
 
-@pytest.mark.asyncio
 async def test_sign_new_user(client: httpx.AsyncClient) -> None:
 
     payload = {
@@ -20,7 +19,6 @@ async def test_sign_new_user(client: httpx.AsyncClient) -> None:
     assert response.json() == test_response
 
 
-@pytest.mark.asyncio
 async def test_sign_user_in(client: httpx.AsyncClient) -> None:
     
     payload = {"username": "testuser@server.com", "password": "testpassword"}

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,4 +1,3 @@
-import pytest
 import httpx
 
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -20,7 +20,7 @@ async def test_sign_new_user(client: httpx.AsyncClient) -> None:
 
 
 async def test_sign_user_in(client: httpx.AsyncClient) -> None:
-    
+
     payload = {"username": "testuser@server.com", "password": "testpassword"}
 
     headers = {

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -91,9 +91,7 @@ async def test_delete_event(
     assert response.json() == test_response
 
 
-async def test_get_event_again(
-    client: httpx.AsyncClient, access_token: str
-) -> None:
+async def test_get_event_again(client: httpx.AsyncClient, access_token: str) -> None:
     headers = {"Authorization": f"Bearer {access_token}"}
     response = await client.get("/event/1", headers=headers)
     assert response.status_code == 404

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -29,7 +29,6 @@ async def mock_event(test_session: AsyncSession) -> AsyncGenerator[Event, None]:
     await test_session.rollback()
 
 
-@pytest.mark.asyncio
 async def test_get_events(
     client: httpx.AsyncClient, mock_event: Event, access_token: str
 ) -> None:
@@ -39,7 +38,6 @@ async def test_get_events(
     assert response.json()[0]["title"] == mock_event.title
 
 
-@pytest.mark.asyncio
 async def test_get_event(
     client: httpx.AsyncClient, mock_event: Event, access_token: str
 ) -> None:
@@ -49,7 +47,6 @@ async def test_get_event(
     assert response.json()["title"] == mock_event.title
 
 
-@pytest.mark.asyncio
 async def test_post_event(client: httpx.AsyncClient, access_token: str) -> None:
     payload = {
         "title": "Event title",
@@ -68,7 +65,6 @@ async def test_post_event(client: httpx.AsyncClient, access_token: str) -> None:
     assert response.json() == test_response
 
 
-@pytest.mark.asyncio
 async def test_update_event(
     client: httpx.AsyncClient, mock_event: Event, access_token: str
 ) -> None:
@@ -82,7 +78,6 @@ async def test_update_event(
     assert response.json()["title"] == test_payload["title"]
 
 
-@pytest.mark.asyncio
 async def test_delete_event(
     client: httpx.AsyncClient, mock_event: Event, access_token: str
 ) -> None:
@@ -96,7 +91,6 @@ async def test_delete_event(
     assert response.json() == test_response
 
 
-@pytest.mark.asyncio
 async def test_get_event_again(
     client: httpx.AsyncClient, access_token: str
 ) -> None:


### PR DESCRIPTION
Часть вещей, на которые можно обратить внимание:
1. pytest давно поддерживает асинхронные тесты, декораторы pytest.mark.asyncio можно не писать
2. pytest.fixture может быть асинхронной, нет необходимости юзать pytest_asyncio.fixture (библиотеку pytest-asyncio, впрочем, держать в зависимостях пока стоит.
3. Все тестовое окружение стоит создавать отдельно от боевого, session_maker переиспользовать не стоит. 
4. override_get_session - мертвый код, убрал это